### PR TITLE
don't cache magic link req

### DIFF
--- a/src/routes/login/[phone]/[token]/+page.server.ts
+++ b/src/routes/login/[phone]/[token]/+page.server.ts
@@ -2,7 +2,7 @@ import type { PageServerLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 import prisma from '$lib/prisma';
 
-export const load = (async ({ params, cookies }) => {
+export const load = (async ({ params, cookies, setHeaders }) => {
 	console.log('LOAD LOGIN');
 	let magicLinkInfo;
 	try {
@@ -58,6 +58,10 @@ export const load = (async ({ params, cookies }) => {
 		}
 	});
 	console.log('CREATED SESSION', session);
+
+	setHeaders({
+		'cache-control': 'no-store, max-age=0'
+	});
 
 	throw redirect(308, '/dashboard');
 }) satisfies PageServerLoad;


### PR DESCRIPTION
Issue: magic link doesn't work after logging out (on at least Android)

Think the problem might be that the magic link request was cached. Upon hitting it a second time, it immediately takes the user to the dashboard without hitting the magic link endpoint (which sets up a session and everything).

Tested with `vite build && vite preview` but will leave this to @lilith to deploy and play with on Android 👀 This is a pretty important flow so I'd like to be able to rollback immediately if it breaks anything drastically. But if you think it's safe enough, I can just push